### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ idea-sublime-keymap
 
 Dirty version of Sublime keymap for Jetbrains IDEA (PHPStorm, RubyMine, PyCharm, ...)
 
-###Install
+### Install
 
 Copy Sublime.xml to config directory.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
